### PR TITLE
Feature/TIM-82: Fixed sorting by division bug

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -226,7 +226,8 @@ class User(UserMixin, db.Model):
                      password=forgery_py.lorem_ipsum.word(),  # change to set a universal password for QA testing
                      first_name=first,
                      last_name=last,
-                     tag=t
+                     tag=t,
+                     division=''
                      )
             db.session.add(u)
             try:


### PR DESCRIPTION
The system should be able to sort the "Edit User information" page by division even if some User haven't been assigned to a division.

TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'