### PR TITLE
Fixed Password Reset Bug

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -301,8 +301,7 @@ def password_reset(token):
             return render_template("auth/reset_password.html", form=form)
         else:
             try:
-                if 'reset_token' in session and session['reset_token']['valid'] and user.reset_password(token,
-                                                                                                        form.password.data):
+                if 'reset_token' in session and session['reset_token']['valid'] and user.reset_password(token,form.password.data):
                     # If the token has not been used and the user submits a proper new password, reset users password
                     # and login attempts
                     user.login_attempts = 0
@@ -323,11 +322,14 @@ def password_reset(token):
                     return render_template('auth/reset_password.html', form=form)
 
                 else:
-                    # New password didn't meet minimum security criteria
-                    current_app.logger.error(
-                        'Entered invalid new password for {}'.format(user.email))
-                    flash('Password must be at least 8 characters with at least 1 Uppercase Letter and 1 Number',
-                          category='error')
+                    if not 'reset_token' in session: 
+                        flash('The reset token is timed out. Please generate a new reset token.', category='error')
+                    # Then the token is valid but the new password didn't meet minimum security criteria
+                    else:
+                        current_app.logger.error(
+                            'Entered invalid new password for {}'.format(user.email))
+                        flash('Password must be at least 8 characters with at least 1 Uppercase Letter and 1 Number',
+                              category='error')
                     current_app.logger.info('End function password_reset')
                     return render_template('auth/reset_password.html', form=form)
 

--- a/app/models.py
+++ b/app/models.py
@@ -169,7 +169,7 @@ class User(UserMixin, db.Model):
         :return: True if operation is successful, false otherwise.
         """
         # checks if the new password is at least 8 characters with at least 1 UPPERCASE AND 1 NUMBER
-        if len(new_password) <8:
+        if len(new_password) < 8:
             return False
         score = 0
         if re.search('\d+', new_password):

--- a/app/models.py
+++ b/app/models.py
@@ -169,6 +169,8 @@ class User(UserMixin, db.Model):
         :return: True if operation is successful, false otherwise.
         """
         # checks if the new password is at least 8 characters with at least 1 UPPERCASE AND 1 NUMBER
+        if len(new_password) <8:
+            return False
         score = 0
         if re.search('\d+', new_password):
             # If the new password contains a digit, increment score

--- a/app/models.py
+++ b/app/models.py
@@ -169,9 +169,16 @@ class User(UserMixin, db.Model):
         :return: True if operation is successful, false otherwise.
         """
         # checks if the new password is at least 8 characters with at least 1 UPPERCASE AND 1 NUMBER
-        if not re.match(r'^(?=.*?\d)(?=.*?[A-Z])(?=.*?[a-z])[A-Za-z\d]{8,128}$', new_password):
+        score = 0
+        if re.search('\d+', new_password):
+            # If the new password contains a digit, increment score
+            score += 1
+        if re.search('[a-z]', new_password) and re.search('[A-Z]', new_password):
+            # If the new password contains lowercase and uppercase letters, increment score
+            score += 1
+        if score < 2:
             return False
-        # If the password has been changed within the last second, the token is invalid.
+            # If the password has been changed within the last second, the token is invalid.
         if (datetime.now() - self.password_list.last_changed).seconds < 1:
             current_app.logger.error('User {} tried to re-use a token.'.format(self.email))
             raise InvalidResetToken

--- a/app/models.py
+++ b/app/models.py
@@ -169,7 +169,7 @@ class User(UserMixin, db.Model):
         :return: True if operation is successful, false otherwise.
         """
         # checks if the new password is at least 8 characters with at least 1 UPPERCASE AND 1 NUMBER
-        if len(new_password) < 8:
+        if len(new_password) <8:
             return False
         score = 0
         if re.search('\d+', new_password):


### PR DESCRIPTION
-The users should be allowed use symbols in their password while resetting.
-The user should know if the error is coming from an invalid password or a timed-out token