### PR TITLE
Recognizing Emails Only When Using LowerCase Fix

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -35,7 +35,7 @@ class RegistrationForm(Form):
         :param email_field:
         :return:
         """
-        if User.query.filter_by(email=email_field.data).first():
+        if User.query.filter_by(email=email_field.data.lower()).first():
             raise ValidationError('An account with this email address already exists')
         return True
 
@@ -115,7 +115,7 @@ class AdminRegistrationForm(Form):
         :param email_field:
         :return:
         """
-        if User.query.filter_by(email=email_field.data).first():
+        if User.query.filter_by(email=email_field.data.lower()).first():
             # raise ValidationError
             # flash('An account with this email address already exists', 'error')
             self.email.errors = 'An account with this email address already exists',
@@ -220,7 +220,7 @@ class PasswordResetForm(Form):
     submit = SubmitField('Reset Password')
 
     def validate_email(self, field):
-        if User.query.filter_by(email=field.data).first() is None:
+        if User.query.filter_by(email=field.data.lower()).first() is None:
             raise ValidationError('Unknown email address.')
 
 

--- a/app/auth/modules.py
+++ b/app/auth/modules.py
@@ -30,7 +30,7 @@ def check_password_requirements(email, old_password, password, password_confirma
     :return: Whether or not the new password is valid [Boolean]
     """
 
-    user_password = User.query.filter_by(email=email).first().password_hash
+    user_password = User.query.filter_by(email=email.lower()).first().password_hash
 
     if not check_password_hash(pwhash=user_password, password=old_password):
         # If the user enters the wrong current password

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -73,7 +73,7 @@ class AdminFilterEventsForm(Form):
         :param email: The filtered email
         :return:
         """
-        user = User.query.filter_by(email=email.data).first()
+        user = User.query.filter_by(email=email.data.lower()).first()
         if not user:
             raise ValidationError('No account with that email exists')
 
@@ -105,7 +105,7 @@ class CreatePayRateForm(Form):
         :param email: The filtered email
         :return:
         """
-        user = User.query.filter_by(email=email.data).first()
+        user = User.query.filter_by(email=email.data.lower()).first()
         if not user:
             raise ValidationError('No account with that email exists')
 
@@ -136,7 +136,7 @@ class AddEventForm(Form):
         :param email: The supervisor's email
         :return:
         """
-        user = User.query.filter_by(email=email.data).first()
+        user = User.query.filter_by(email=email.data.lower()).first()
         if not user:
             raise ValidationError('No account with that email exists')
 
@@ -167,7 +167,7 @@ class FilterTimePunchForm(Form):
         :param email: The email
         :return:
         """
-        user = User.query.filter_by(email=email.data).first()
+        user = User.query.filter_by(email=email.data.lower()).first()
         if not user:
             raise ValidationError('No account with that email exists')
 
@@ -198,7 +198,7 @@ class FilterVacationForm(Form):
         :param email: The email
         :return:
         """
-        user = User.query.filter_by(email=email.data).first()
+        user = User.query.filter_by(email=email.data.lower()).first()
         if not user:
             raise ValidationError('No account with that email exists')
 

--- a/app/main/modules.py
+++ b/app/main/modules.py
@@ -170,9 +170,9 @@ def get_events_by_date(email=None, first_date_input=None, last_date_input=None, 
 
     # User processing
     if email_input is not None:
-        if User.query.filter_by(email=email_input).first() is not None:
+        if User.query.filter_by(email=email_input.lower()).first() is not None:
             current_app.logger.info('Querying for events with given user: {}'.format(email_input))
-            user_id = User.query.filter_by(email=email_input).first().id
+            user_id = User.query.filter_by(email=email_input.lower()).first().id
             events_query = events_query.filter(Event.user_id == user_id)
             current_app.logger.info('Finished querying for events with given user.')
         elif email_input != '':

--- a/app/main/payments.py
+++ b/app/main/payments.py
@@ -18,7 +18,7 @@ def get_payrate_before_or_after(email_input, start, before_or_after):
     """
     current_app.logger.info('Start function get_pay_before()')
     current_app.logger.info('Querying for user with given e-mail: {}'.format(email_input))
-    user = User.query.filter_by(email=email_input).first()
+    user = User.query.filter_by(email=email_input.lower()).first()
     current_app.logger.info('Finished querying for user with given e-mail')
     if user:
         current_app.logger.info('User {} was found in database'.format(email_input))

--- a/app/main/pdf.py
+++ b/app/main/pdf.py
@@ -45,9 +45,9 @@ def generate_employee_info(canvas_field):
     """
     current_app.logger.info('PDF: Generating employee info...')
     if session['email'] is None or session['email'] == '':
-        u = User.query.filter_by(email=current_user.email).first()
+        u = User.query.filter_by(email=current_user.email.lower()).first()
     else:
-        u = User.query.filter_by(email=session['email']).first()
+        u = User.query.filter_by(email=session['email'].lower()).first()
 
     first_date = session['first_date']
     last_date = session['last_date']

--- a/app/main/requests.py
+++ b/app/main/requests.py
@@ -44,14 +44,14 @@ def get_timepunches_for_review(user_email, filter_by_email=None, status=None):
     :return: A query of all timepunch requests for the given user
     """
     current_app.logger.info('Start function get_timepunches_for_review()')
-    u = User.query.filter_by(email=user_email).first()
+    u = User.query.filter_by(email=user_email.lower()).first()
     current_app.logger.info('Querying for timepunches submitted to {}'.format(user_email))
     timepunch_query = Event.query.join(User).filter_by(supervisor=u).filter(Event.timepunch == True).order_by(Event.id)
     current_app.logger.info('Finished querying for timepunches')
 
     # Filter by emails if user provides an email
     if filter_by_email and filter_by_email != '':
-        u = User.query.filter_by(email=filter_by_email).first()
+        u = User.query.filter_by(email=filter_by_email.lower()).first()
         if u:
             timepunch_query = timepunch_query.filter(Event.user_id == u.id)
         else:
@@ -108,14 +108,14 @@ def get_vacations_for_review(user_email, filter_by_email=None, status=None):
     :return: A query of all vacation requests for the given user
     """
     current_app.logger.info('Start function get_timepunches_for_review()')
-    u = User.query.filter_by(email=user_email).first()
+    u = User.query.filter_by(email=user_email.lower()).first()
     current_app.logger.info('Querying for vacations submitted to {}'.format(user_email))
     vacation_query = Vacation.query.join(User).filter_by(supervisor=u).order_by(Vacation.id)
     current_app.logger.info('Finished querying for vacations')
 
     # Filter by emails if user provides an email
     if filter_by_email and filter_by_email != '':
-        u = User.query.filter_by(email=filter_by_email).first()
+        u = User.query.filter_by(email=filter_by_email.lower()).first()
         if u:
             vacation_query = vacation_query.filter(Vacation.user_id == u.id)
         else:

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -157,7 +157,7 @@ def all_history():
 
     addform = AddEventForm()
     if addform.validate_on_submit() and addform.add.data:
-        if addform.addemail.data == current_user.email:
+        if addform.addemail.data.lower() == current_user.email:
             flash('Administrators cannot edit their own clock events', 'error')
             return redirect(url_for('main.clear'))
         date_string = addform.add_date.data.strftime('%m/%d/%Y ')
@@ -168,7 +168,7 @@ def all_history():
         except ValueError:
             flash('Please make sure your time input is in the format HH:MM', category='error')
             return redirect(url_for('main.all_history'))
-        u = User.query.filter_by(email=addform.addemail.data).first()
+        u = User.query.filter_by(email=addform.addemail.data.lower()).first()
         add_event(u.id, datetime_obj, (addform.addpunch_type.data == "In"))
         flash("Clock event successfully processed", 'success')
         return redirect(url_for('main.clear'))
@@ -378,9 +378,9 @@ def download_invoice():
         session['email'] += '@records.nyc.gov'
 
     if session['email'] is None or session['email'] == '':
-        u = User.query.filter_by(email=current_user.email).first()
+        u = User.query.filter_by(email=current_user.email.lower()).first()
     else:
-        u = User.query.filter_by(email=session['email']).first()
+        u = User.query.filter_by(email=session['email'].lower()).first()
 
     # Check for payrate
     if get_payrate_before_or_after(session['email'], session['first_date'], True) is None:
@@ -453,7 +453,7 @@ def pay():
     form = CreatePayRateForm()
     if form.validate_on_submit():
         current_app.logger.info('Querying for user with email {}'.format(form.email.data))
-        u = User.query.filter_by(email=form.email.data).first()
+        u = User.query.filter_by(email=form.email.data.lower()).first()
         current_app.logger.info('Finished querying for user')
         if not u:
             current_app.logger.error('Tried creating pay for {}. A user with this email does not exist.'.
@@ -542,7 +542,7 @@ def review_timepunch():
     clear_form = ClearForm()
     page = request.args.get('page', 1, type=int)
     if filter_form.validate_on_submit and filter_form.filter.data:
-        if not filter_form.email.data or User.query.filter_by(email=filter_form.email.data).first():
+        if not filter_form.email.data or User.query.filter_by(email=filter_form.email.data.lower()).first():
             flash('Successfully filtered', 'success')
         else:
             flash('Invalid email', 'error')
@@ -637,7 +637,7 @@ def review_vacations():
     clear_form = ClearForm()
     page = request.args.get('page', 1, type=int)
     if filter_form.validate_on_submit and filter_form.filter.data:
-        if not filter_form.email.data or User.query.filter_by(email=filter_form.email.data).first():
+        if not filter_form.email.data or User.query.filter_by(email=filter_form.email.data.lower()).first():
             flash('Successfully filtered', 'success')
         else:
             flash('Invalid email', 'error')


### PR DESCRIPTION
The system should recognize emails even if the user used upper case letters. For example when admin registers a new user using upper case with an email that already exists, it throws a sqlalchemy.exc.IntegrityErro when it should flash "An account with this email address already exists". The same thing when filtering TimePunch, creating pay rate form, or adding new events for specific user.