### PR TITLE
Time Sheet Accuracy

### DIFF
--- a/app/main/modules.py
+++ b/app/main/modules.py
@@ -335,22 +335,17 @@ def check_total_clock_count(events):
     :return: True if there are matching clock outs for each clock in, otherwise False
     """
     current_app.logger.info('Start function check_total_clock_count()')
-    clock_in_list = []
-    clock_out_list = []
-    # loop through all events and count the number of clock-ins and clock-outs in separate lists
-    for event in events:
-        if 'OUT' in event:
-            clock_out_list.append(event)
-        elif 'IN' in event:
-            clock_in_list.append(event)
-        else:
-            continue
-    if len(clock_out_list) == len(clock_in_list):
-        return True
-    else:
+    if len(events) % 2 != 0:
         return False
-
-
+    #Each clock in must have corresponding clock out i.e There should be no two consecutive ones of the same type.
+    last_type_clock="IN"
+    for event in events:
+        if last_type_clock in event:
+            return False
+        elif last_type_clock=="OUT":
+            last_type_clock="IN"
+        else: last_type_clock="OUT"
+    return True
 def add_event(user_id, time, type):
     """
     Adds an event to the database

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -305,7 +305,7 @@ def download():
 
     if not (check_total_clock_count(events)):
         current_app.logger.error('Timesheet was generated with odd number of clock ins/outs {}'.format(len(events)))
-        flash('Each clock in must have corresponding clock out to generate a invoice. '
+        flash('Each clock in must have corresponding clock out to generate a timesheet. '
               'Please submit a timepunch for missing times.', category='error')
         return redirect(url_for('main.' + (request.referrer).split('/')[3]))
     if errors:
@@ -392,7 +392,7 @@ def download_invoice():
     all_info = calculate_hours_worked(session['email'], session['first_date'], session['last_date'])
     if not all_info:
         current_app.logger.error('Invoice was generated with odd number of clock ins/outs {}')
-        flash('Each clock in must have corresponding clock out to generate a invoice. '
+        flash('Each clock in must have corresponding clock out to generate an invoice. '
               'Please submit a timepunch for missing times.', category='error')
         return redirect(url_for('main.' + last_page))
     day_events_list = all_info['days_list']


### PR DESCRIPTION
When trying to generate a time sheet, the system should make sure that each "clock in" must have corresponding "clock out" instead of just making a loop through all events and just counting the number of clock-ins and clock-outs. It should make sure that there should be no two consecutive clock punches of the same type and that the first event is a "clock in" and last one is a "clock out".