### PR TITLE
Fix invalid calculation of hours worked

### DIFF
--- a/app/main/payments.py
+++ b/app/main/payments.py
@@ -74,7 +74,8 @@ def calculate_hours_worked(email_input, start, end):
         time_out = next_event.time
         payrate_this_day = get_payrate_before_or_after(email_input, time_in.date(), True)
         hours_this_day = (time_out - time_in).seconds / float(3600)
-        hours_this_day = hours_this_day - 1 if hours_this_day >= 5 else hours_this_day
+        if hours_this_day >= 5:
+            hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else hours_this_day = 5
         day_dict = {
             'date': time_in.strftime('%a %b %d, %Y'),
             'time_in': time_in.strftime('%H:%M'),

--- a/app/main/payments.py
+++ b/app/main/payments.py
@@ -75,7 +75,7 @@ def calculate_hours_worked(email_input, start, end):
         payrate_this_day = get_payrate_before_or_after(email_input, time_in.date(), True)
         hours_this_day = (time_out - time_in).seconds / float(3600)
         if hours_this_day >= 5:
-            hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else hours_this_day = 5
+            hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else 5
         day_dict = {
             'date': time_in.strftime('%a %b %d, %Y'),
             'time_in': time_in.strftime('%H:%M'),

--- a/app/main/pdf.py
+++ b/app/main/pdf.py
@@ -120,10 +120,9 @@ def generate_timetable(canvas_field, events):
         time_out_datetime = datetime.strptime(time_out, "%b %d, %Y %H:%M:%S %p")
 
         date = time_in_datetime.strftime('%a %b %d, %Y')
-        hours_this_day = (time_out_datetime - time_in_datetime).seconds / float(3600)
-        hours_this_day = (hours_this_day - 1
-                          if hours_this_day >= 5
-                          else hours_this_day)
+        hours_this_day = (time_out - time_in).seconds / float(3600)
+        if hours_this_day >= 5:
+            hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else hours_this_day = 5
         total_hours += hours_this_day
 
         next_line -= padding

--- a/app/main/pdf.py
+++ b/app/main/pdf.py
@@ -120,7 +120,7 @@ def generate_timetable(canvas_field, events):
         time_out_datetime = datetime.strptime(time_out, "%b %d, %Y %H:%M:%S %p")
 
         date = time_in_datetime.strftime('%a %b %d, %Y')
-        hours_this_day = (time_out - time_in).seconds / float(3600)
+        hours_this_day = (time_out_datetime - time_in_datetime).seconds / float(3600)
         if hours_this_day >= 5:
             hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else 5
         total_hours += hours_this_day

--- a/app/main/pdf.py
+++ b/app/main/pdf.py
@@ -122,7 +122,7 @@ def generate_timetable(canvas_field, events):
         date = time_in_datetime.strftime('%a %b %d, %Y')
         hours_this_day = (time_out - time_in).seconds / float(3600)
         if hours_this_day >= 5:
-            hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else hours_this_day = 5
+            hours_this_day = hours_this_day - 1 if hours_this_day >= 6 else 5
         total_hours += hours_this_day
 
         next_line -= padding


### PR DESCRIPTION

<img width="1066" alt="Screen Shot 2019-08-22 at 9 16 57 AM" src="https://user-images.githubusercontent.com/46773316/63518116-55926a80-c4be-11e9-8217-87e470ed3d02.png">
The system shouldn't subtract an hour for lunch if hours worked is between 5 and 6 hours. In that case it should just reset the hours worked to 5. Because now it's impossible to work for just 5 hours even if your timing is perfectly.