### PR TITLE
Undo Biweekly Timesheet Generation

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -122,7 +122,7 @@ class UserFilterEventsForm(Form):
 
     last_month = SubmitField("Last Month")
     this_month = SubmitField("This Month")
-    last_2weeks = SubmitField("Biweekly")
+    last_2weeks = SubmitField("Last Two Weeks")
     last_week = SubmitField("Last Week")
     this_week = SubmitField("This Week")
 

--- a/app/main/modules.py
+++ b/app/main/modules.py
@@ -251,7 +251,7 @@ def get_time_period(period="d"):
         m (this month)
         ld (last day i.e. yesterday)
         lw (last week)
-        l2w (last 2 weeks i.e This week and last week)
+        l2w (last 2 weeks i.e last week and the week before)
         lm (last month)
     :return: A two-element array containing a start and end date
     """
@@ -279,7 +279,7 @@ def get_time_period(period="d"):
         end = start + timedelta(days=6)
         interval = [start, end]
     elif period == "l2w":
-        dt = today + relativedelta(weeks=-1)
+        dt = today + relativedelta(weeks=-2)
         start = dt - timedelta(days=dt.weekday())
         end = start + timedelta(days=13)
         interval = [start, end]

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -338,13 +338,13 @@ def download():
             "did not specify a user".format(current_user.email)
         )
         errors.append("You must specify a user.")
-    if (session["last_date"] - session["first_date"]).days > 15:
+    if (session["last_date"] - session["first_date"]).days > 8:
         current_app.logger.error(
             "User {} tried to generate a timesheet but "
-            "exceeded maximum duration (two weeks)".format(current_user.email)
+            "exceeded maximum duration (one week)".format(current_user.email)
         )
         errors.append(
-            "Maximum timesheet duration is two weeks. " "Please refine your filters"
+            "Maximum timesheet duration is a week. " "Please refine your filters"
         )
 
     events = request.form.getlist(
@@ -419,11 +419,11 @@ def download_invoice():
         # If the time period is over a week, flash an error. We use days > 8
         # because we use a < as opposed to a <= in our query in modules.py
         current_app.logger.error(
-            "User {} tried to generate a timesheet but "
+            "User {} tried to generate an invoice but "
             "exceeded maximum duration (one week)".format(current_user.email)
         )
         errors.append(
-            "Maximum timesheet duration is a week. " "Please refine your filters"
+            "Maximum invoice duration is a week. " "Please refine your filters"
         )
     if errors:
         for error in errors:


### PR DESCRIPTION
-User shouldn't be able to generate a timesheet with more than one week duration.
-Fix "Last two Weeks" duration to be last week and the week before
-Fix some typos