### PR TITLE
History Collapsing Forms

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -177,6 +177,12 @@ def all_history():
 
     addform = AddEventForm()
     today = datetime.today()
+    add_event_request = False
+    filter_request = False
+    if request.method == 'POST':
+        if "add" not in request.form:
+            filter_request = True
+        else : add_event_request = True
     if addform.validate_on_submit() and addform.add.data:
         if addform.addemail.data.lower() == current_user.email:
             flash("Administrators cannot edit their own clock events", "error")
@@ -253,6 +259,8 @@ def all_history():
         tags=tags,
         generation_events=events_query.all(),
         query_has_results=query_has_results,
+        filter_request=filter_request,
+        add_request=add_event_request,
     )
 
 

--- a/app/templates/main/all_history.html
+++ b/app/templates/main/all_history.html
@@ -42,7 +42,11 @@
     <br/>
 
     {#  Collapsible form for filter options  #}
+    {%if filter_request %}
+    <div id="filter-form" class="panel-collapse collapse in">
+    {% else  %}
     <div id="filter-form" class="collapse">
+    {% endif  %}
         <div class="row" style="margin-bottom: 10px">
             <div class="col-md-8 col-md-offset-2">
                 {{ wtf.quick_form(form) }}
@@ -151,7 +155,11 @@
         <button data-toggle="collapse" data-target="#add-form" class="btn btn-info" style="float:left"> Add
             Event
         </button>
+        {% if add_request %}
+        <div id="add-form" class="panel-collapse collapse in">
+        {% else %}
         <div id="add-form" class="collapse">
+        {% endif %}
             <div class="row" style="margin-bottom: 10px">
                 <div class="col-md-8 col-md-offset-2">
                     {{ wtf.quick_form(addform) }}


### PR DESCRIPTION
When adding a new event or filtering results using an invalid input(such as email). The page refreshes and the forms collapse before admin sees what was the error.
Closes #22 