### PR TITLE
Fixed default value of date fields in forms

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -51,7 +51,7 @@ class TimePunchForm(Form):
         choices=[("In", "In"), ("Out", "Out")],
     )
     punch_date = DateField(
-        u"Date", default=datetime.today(), validators=[DataRequired()]
+        u"Date", default=datetime.today, validators=[DataRequired()]
     )
     punch_time = StringField(
         u"Time (24-hour)", default="9:00", validators=[DataRequired()]
@@ -66,10 +66,10 @@ class RequestVacationForm(Form):
     """
 
     vac_start = DateField(
-        u"Start Date", default=datetime.today(), validators=[DataRequired()]
+        u"Start Date", default=datetime.today, validators=[DataRequired()]
     )
     vac_end = DateField(
-        u"End Date", default=datetime.today(), validators=[DataRequired()]
+        u"End Date", default=datetime.today, validators=[DataRequired()]
     )
     vac_request = SubmitField("Submit Request")
 
@@ -82,13 +82,11 @@ class AdminFilterEventsForm(Form):
     Administrators can search for clock events created by a given user between first_date and second_date.
     """
 
-    from .modules import get_time_period
+    from .modules import start_of_week
 
     email = StringField("Username/Email", validators=[Optional()])
-    first_date = DateField(
-        "From", default=get_time_period("w")[0], validators=[Optional()]
-    )
-    last_date = DateField("To", default=date.today(), validators=[Optional()])
+    first_date = DateField("From", default=start_of_week, validators=[Optional()])
+    last_date = DateField("To", default=datetime.today, validators=[Optional()])
     tag = SelectField("Tag", choices=tags, coerce=int, validators=[Optional()])
     division = SelectField("Division", choices=divisions, validators=[Optional()])
     submit = SubmitField("Filter")
@@ -132,7 +130,7 @@ class CreatePayRateForm(Form):
     """
 
     email = StringField("Email", validators=[DataRequired(), Email()])
-    start_date = DateField("Start", default=date.today(), validators=[DataRequired()])
+    start_date = DateField("Start", default=datetime.today, validators=[DataRequired()])
     rate = FloatField("Rate", validators=[DataRequired()])
     submit = SubmitField("Create Pay Rate")
 
@@ -164,7 +162,7 @@ class AddEventForm(Form):
     """
 
     addemail = StringField("Email", validators=[DataRequired(), Email()])
-    add_date = DateField(u"Date", default=datetime.today(), validators=[DataRequired()])
+    add_date = DateField(u"Date", default=datetime.today, validators=[DataRequired()])
     add_time = StringField(
         u"Time (24-hour)", default="9:00", validators=[DataRequired()]
     )
@@ -270,10 +268,10 @@ class GenerateMultipleTimesheetsForm(Form):
 
     emails = SelectMultipleField(choices=[], validators=[DataRequired()], coerce=str)
     start_date = DateField(
-        u"Start Date", default=datetime.today(), validators=[DataRequired()]
+        u"Start Date", default=datetime.today, validators=[DataRequired()]
     )
     end_date = DateField(
-        u"End Date", default=datetime.today(), validators=[DataRequired()]
+        u"End Date", default=datetime.today, validators=[DataRequired()]
     )
     gen_timesheets = SubmitField("Generate Timesheets")
 

--- a/app/main/modules.py
+++ b/app/main/modules.py
@@ -295,6 +295,15 @@ def get_time_period(period="d"):
     return interval
 
 
+def start_of_week():
+    """
+    Gets the start of the work week (Monday).
+    Used primarily for setting the default value of date fields.
+    :return: A datetime of the first work day of the current week.
+    """
+    return datetime.today() - timedelta(days=datetime.today().weekday())
+
+
 def process_time_periods(form):
     """
     Runs through the possible submit buttons on AdminFilterEventsForms and UserFilterEventsForms.

--- a/app/main/payments.py
+++ b/app/main/payments.py
@@ -32,7 +32,7 @@ def get_payrate_before_or_after(email_input, start, before_or_after):
                 .order_by(sqlalchemy.desc(Pay.start))
                 .all()
             )
-            p = p[0]
+            p = p[0] if p else None
             # Get the first payment before the given date
         else:
             p = pay_query.filter(Pay.start >= start).first()


### PR DESCRIPTION
This PR fixes the default value of date fields in forms.

Previously setting `default=datetime.today()` would only be set once when the application starts. Fixed by changing the value to a callable so that it gets called every time the form is initialized.

Fixed a bug when generating invoices if the pay rate doesn't cover the start date of the All History filter.